### PR TITLE
Typography

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@fortawesome/react-fontawesome": "^0.1.9",
     "@lingui/detect-locale": "^3.12.1",
     "@lingui/react": "^3.12.1",
+    "@tailwindcss/typography": "^0.4.1",
     "@testing-library/jest-dom": "5.11.5",
     "@testing-library/react": "11.1.0",
     "@testing-library/user-event": "12.1.10",

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -7,7 +7,7 @@ const Content = lazy(() => importMDX('../about.mdx'));
 
 export default function About () {
   return (
-    <div className="page p-4">
+    <div className="page p-4 markdown max-w-screen-lg">
       <Helmet>
         <title>Einakter: {t`About`}</title>
       </Helmet>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const { NONAME } = require('dns')
+
 module.exports = {
   mode: 'jit',
   purge: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
@@ -14,11 +16,42 @@ module.exports = {
           100: '#ebf0f7',
           200: '#1f244809',
         }
-      }
+      },
+      typography: {
+        DEFAULT: {
+          css: {
+            color: '#333',
+            strong: {
+              fontWeight: '500',
+            },
+            h1: {
+              fontWeight: '500',
+            },
+            h2: {
+              fontWeight: '500',
+            },
+            h3: {
+              fontWeight: '500',
+            },
+            a: {
+              color: '#08f',
+                '&:hover': {
+                color: '#0056b3',
+              },
+              fontWeight: '400',
+              textDecoration: false,
+            },
+          },
+        },
+      },  
     },
   },
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/typography')({
+      className: 'markdown',
+    }),
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3357,6 +3357,16 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@tailwindcss/typography@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.4.1.tgz#51ddbceea6a0ee9902c649dbe58871c81a831212"
+  integrity sha512-ovPPLUhs7zAIJfr0y1dbGlyCuPhpuv/jpBoFgqAc658DWGGrOBWBMpAWLw2KlzbNeVk4YBJMzue1ekvIbdw6XA==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    lodash.uniq "^4.5.0"
+
 "@testing-library/dom@^7.26.0":
   version "7.26.3"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.26.3.tgz#5554ee985f712d621bd676104b879f85d9a7a0ef"
@@ -9968,15 +9978,30 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=
+
 lodash.get@^4, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
This PR adds @tailwindcss/typography. A plugin that provides a set of `markdown` classes we can use to add typographic defaults to any vanilla HTML rendered from Markdown.