### PR TITLE
Redesign statistics

### DIFF
--- a/src/components/OriginalStatistics.tsx
+++ b/src/components/OriginalStatistics.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Trans} from '@lingui/macro';
+import {Th, Td} from './Statistics';
 import {OriginalPlay} from '../types';
 import {localLanguageName} from '../languages';
 
@@ -42,28 +43,11 @@ const OriginalStatistics = ({plays = [], className = ''}: Props) => {
   return (
     <div className={className}>
       <table className="table-fixed m-0">
-        <tbody>
-          <td className="w-1/6 pl-0">
-            <p className="md:text-6xl text-4xl font-thin">{plays.length}</p>
-            <p className="font-medium max-w-[20ch]">
-              <Trans>Number of originals</Trans>
-            </p>
-          </td>
-          <td className="w-1/6 pl-0">
-            <p className="md:text-6xl text-4xl font-thin">
-              {Object.keys(names).length}
-            </p>
-            <p className="font-medium max-w-[20ch]">
-              <Trans>Authors</Trans>
-            </p>
-          </td>
-          <td className="w-1/6 pl-0">
-            <p className="md:text-6xl text-4xl font-thin">{anonymous}</p>
-            <p className="font-medium max-w-[20ch]">
-              <Trans>Plays published anonymously</Trans>
-            </p>
-          </td>
-          <td className="w-3/6 pl-0">
+        <tr>
+          <Td width="1/6">{plays.length}</Td>
+          <Td width="1/6">{Object.keys(names).length}</Td>
+          <Td width="1/6">{anonymous}</Td>
+          <td className="w-3/6 pl-0 pb-0">
             {Object.keys(languages).sort((a, b) => {
               if (languages[a] > languages[b]) {
                 return -1;
@@ -75,14 +59,20 @@ const OriginalStatistics = ({plays = [], className = ''}: Props) => {
             }).map((code, i) => (
               <span key={code}>
                 {i > 0 && ', '}
-                <span className="whitespace-nowrap">{localLanguageName(code)}: <span className="font-medium">{languages[code]}</span></span>
+                <span className="whitespace-nowrap">
+                  {localLanguageName(code)}:{' '}
+                  <b className="font-medium">{languages[code]}</b>
+                </span>
               </span>
             ))}
-            <p className="font-medium max-w-[20ch]">
-            <Trans>Languages</Trans>
-            </p>
           </td>
-        </tbody>
+        </tr>
+        <tr>
+          <Th width="1/6"><Trans>Number of originals</Trans></Th>
+          <Th width="1/6"><Trans>Authors</Trans></Th>
+          <Th width="1/6"><Trans>Plays published anonymously</Trans></Th>
+          <Th><Trans>Languages</Trans></Th>
+        </tr>
       </table>
     </div>
   );

--- a/src/components/OriginalStatistics.tsx
+++ b/src/components/OriginalStatistics.tsx
@@ -41,49 +41,47 @@ const OriginalStatistics = ({plays = [], className = ''}: Props) => {
 
   return (
     <div className={className}>
-      <table className="table-auto m-0">
+      <table className="table-fixed m-0">
         <tbody>
-          <tr>
-            <th>
+          <td className="w-1/6 pl-0">
+            <p className="md:text-6xl text-4xl font-thin">{plays.length}</p>
+            <p className="font-medium max-w-[20ch]">
               <Trans>Number of originals</Trans>
-            </th>
-            <td>{plays.length}</td>
-          </tr>
-          <tr>
-            <th>
-              <Trans>Authors</Trans>
-            </th>
-            <td>
+            </p>
+          </td>
+          <td className="w-1/6 pl-0">
+            <p className="md:text-6xl text-4xl font-thin">
               {Object.keys(names).length}
-            </td>
-          </tr>
-          <tr>
-            <th>
+            </p>
+            <p className="font-medium max-w-[20ch]">
+              <Trans>Authors</Trans>
+            </p>
+          </td>
+          <td className="w-1/6 pl-0">
+            <p className="md:text-6xl text-4xl font-thin">{anonymous}</p>
+            <p className="font-medium max-w-[20ch]">
               <Trans>Plays published anonymously</Trans>
-            </th>
-            <td>{anonymous}</td>
-          </tr>
-          <tr>
-            <th>
-              <Trans>Languages</Trans>
-            </th>
-            <td>
-              {Object.keys(languages).sort((a, b) => {
-                if (languages[a] > languages[b]) {
-                  return -1;
-                }
-                if (languages[a] < languages[b]) {
-                  return 1;
-                }
-                return 0;
-              }).map((code, i) => (
-                <span key={code}>
-                  {i > 0 && ', '}
-                  {localLanguageName(code)} ({languages[code]})
-                </span>
-              ))}
-            </td>
-          </tr>
+            </p>
+          </td>
+          <td className="w-3/6 pl-0">
+            {Object.keys(languages).sort((a, b) => {
+              if (languages[a] > languages[b]) {
+                return -1;
+              }
+              if (languages[a] < languages[b]) {
+                return 1;
+              }
+              return 0;
+            }).map((code, i) => (
+              <span key={code}>
+                {i > 0 && ', '}
+                <span className="whitespace-nowrap">{localLanguageName(code)}: <span className="font-medium">{languages[code]}</span></span>
+              </span>
+            ))}
+            <p className="font-medium max-w-[20ch]">
+            <Trans>Languages</Trans>
+            </p>
+          </td>
         </tbody>
       </table>
     </div>

--- a/src/components/Statistics.tsx
+++ b/src/components/Statistics.tsx
@@ -65,46 +65,43 @@ const Statistics = ({authors = {}, plays = [], className = ''}: Props) => {
 
   return (
     <div className={className}>
-      <table className="table-auto m-0">
+      <table className="table-fixed md:w-full m-0">
         <tbody>
-          <tr>
-            <th>
+          <td className="w-1/5 pl-0">
+            <p className="md:text-6xl text-4xl font-thin">{plays.length}</p>
+            <p className="font-medium">
               <Trans>One-act plays</Trans>
-            </th>
-            <td>{plays.length}</td>
-          </tr>
-          <tr>
-            <th>
-              <Trans>Authors</Trans>
-            </th>
-            <td>
-              {authorsTotal}
-              <br/>
+            </p>
+          </td>
+          <td className="w-1/5 pl-0">
+              <span className="md:text-6xl text-4xl font-thin">{authorsTotal}</span>
+              <p className="font-medium">
+                <Trans>Authors</Trans>
+              </p>
               <small>
-                Wikidata: {authorsWikidata},{' '}
+                Wikidata: {authorsWikidata},{' '}<br/> 
                 <Trans>male</Trans>: {authorsMale},{' '}
                 <Trans>female</Trans>: {authorsFemale}
               </small>
-            </td>
-          </tr>
-          <tr>
-            <th>
+          </td>
+          <td className="w-1/5 pl-0">
+            <p className="md:text-6xl text-4xl font-thin">{anonymous}</p>
+            <p className="font-medium max-w-[20ch]">
               <Trans>Plays published anonymously</Trans>
-            </th>
-            <td>{anonymous}</td>
-          </tr>
-          <tr>
-            <th>
+            </p>
+          </td>
+          <td className="w-1/5 pl-0">
+            <p className="md:text-6xl text-4xl font-thin">{plays.filter(p => p.basedOn?.length).length}</p>
+            <p className="font-medium max-w-[20ch]">
               <Trans>Plays translated/adapted from other languages</Trans>
-            </th>
-            <td>{plays.filter(p => p.basedOn?.length).length}</td>
-          </tr>
-          <tr>
-            <th>
+            </p>
+          </td>
+          <td className="w-1/5 pl-0">
+            <p className="md:text-6xl text-4xl font-thin">{numCharacters}</p>
+            <p className="font-medium">
               <Trans>Characters</Trans>
-            </th>
-            <td>{numCharacters}</td>
-          </tr>
+            </p>
+          </td>
         </tbody>
       </table>
     </div>

--- a/src/components/Statistics.tsx
+++ b/src/components/Statistics.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {ReactNode} from 'react';
 import {Trans} from '@lingui/macro';
 import {Play} from '../types';
 
@@ -18,6 +18,36 @@ interface AuthorData {
       placeId?: string
     }
   }
+};
+
+export const Td = (
+  {className, children, width}: {
+    children: ReactNode;
+    className?: string;
+    width?: string;
+  }
+) => {
+  return (
+    <td className={
+      `w-${width || '1/5'} pl-0 pb-0 md:text-6xl text-4xl font-thin ${className || ''}`
+    }>
+      {children}
+    </td>
+  );
+};
+
+export const Th = (
+  {className, children, width}: {
+    children: ReactNode;
+    className?: string;
+    width?: string;
+  }
+) => {
+  return (
+    <th className={`w-${width || '1/5'} pl-0 pt-0 text-base ${className || ''}`}>
+      {children}
+    </th>
+  );
 };
 
 interface Props {
@@ -66,43 +96,37 @@ const Statistics = ({authors = {}, plays = [], className = ''}: Props) => {
   return (
     <div className={className}>
       <table className="table-fixed md:w-full m-0">
-        <tbody>
-          <td className="w-1/5 pl-0">
-            <p className="md:text-6xl text-4xl font-thin">{plays.length}</p>
-            <p className="font-medium">
-              <Trans>One-act plays</Trans>
+        <tr className="bg-transparent">
+          <Td>{plays.length}</Td>
+          <Td>{authorsTotal}</Td>
+          <Td>{anonymous}</Td>
+          <Td>{plays.filter(p => p.basedOn?.length).length}</Td>
+          <Td>{numCharacters}</Td>
+        </tr>
+        <tr className="bg-transparent">
+          <Th>
+            <Trans>One-act plays</Trans>
+          </Th>
+          <Th>
+            <p>
+              <Trans>Authors</Trans>
             </p>
-          </td>
-          <td className="w-1/5 pl-0">
-              <span className="md:text-6xl text-4xl font-thin">{authorsTotal}</span>
-              <p className="font-medium">
-                <Trans>Authors</Trans>
-              </p>
-              <small>
-                Wikidata: {authorsWikidata},{' '}<br/> 
-                <Trans>male</Trans>: {authorsMale},{' '}
-                <Trans>female</Trans>: {authorsFemale}
-              </small>
-          </td>
-          <td className="w-1/5 pl-0">
-            <p className="md:text-6xl text-4xl font-thin">{anonymous}</p>
-            <p className="font-medium max-w-[20ch]">
-              <Trans>Plays published anonymously</Trans>
-            </p>
-          </td>
-          <td className="w-1/5 pl-0">
-            <p className="md:text-6xl text-4xl font-thin">{plays.filter(p => p.basedOn?.length).length}</p>
-            <p className="font-medium max-w-[20ch]">
+            <small className="font-normal">
+              Wikidata: {authorsWikidata},{' '}<br/> 
+              <Trans>male</Trans>: {authorsMale},{' '}
+              <Trans>female</Trans>: {authorsFemale}
+            </small>
+          </Th>
+          <Th className="max-w-[20ch]">
+            <Trans>Plays published anonymously</Trans>
+          </Th>
+          <Th className="max-w-[20ch]">
               <Trans>Plays translated/adapted from other languages</Trans>
-            </p>
-          </td>
-          <td className="w-1/5 pl-0">
-            <p className="md:text-6xl text-4xl font-thin">{numCharacters}</p>
-            <p className="font-medium">
-              <Trans>Characters</Trans>
-            </p>
-          </td>
-        </tbody>
+          </Th>
+          <Th>
+            <Trans>Characters</Trans>
+          </Th>
+        </tr>
       </table>
     </div>
   );

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -119,6 +119,9 @@ function Table () {
         {
           props => (
             <div className="p-4 overflow-x-auto">
+              <h1>
+                <Trans>Welcome</Trans>
+              </h1>
               <p>
                 <Trans>
                   Welcome to <b>Einakter</b>, the <b>Database of German-Language


### PR DESCRIPTION
This PR introduces a more prominent statistics overview before Plays and Originals tables. It also adds a heading for the Plays page which will require translations. Some `Trans` lines moved as well.