### PR TITLE
Fix typo in Toki Pona translation

### DIFF
--- a/src/locales/jbo-tok/messages.po
+++ b/src/locales/jbo-tok/messages.po
@@ -213,7 +213,7 @@ msgstr "pali musi pi lipu wan tawa toki ante"
 
 #: src/components/Home.tsx:32
 msgid "Our aim is to provide a general quantitative overview of one-act plays written in German between the mid-18th and mid-19th centuries. For more information, including how to cite this database, please see the About page."
-msgstr "mi mute li wile e ni: mi pana e sona nanpa pi lipu sona pi pali musi pi lipu wan kepeken toki Tonsi lon sike suno 1740–1850. sina wile kama sona mute la o lukin e lipu «sona pi pali ni»."
+msgstr "mi mute li wile e ni: mi pana e sona nanpa pi lipu sona pi pali musi pi lipu wan kepeken toki Tosi lon sike suno 1740–1850. sina wile kama sona mute la o lukin e lipu «sona pi pali ni»."
 
 #: src/components/Topnav.tsx:93
 msgid "Plays"
@@ -268,11 +268,11 @@ msgstr "toki Epanja"
 
 #: src/components/Home.tsx:12
 msgid "The Database of German-Language One-Act Plays 1740–1850"
-msgstr "lipu sona pi pali musi pi lipu wan kepeken toki Tonsi lon 1740–1850"
+msgstr "lipu sona pi pali musi pi lipu wan kepeken toki Tosi lon 1740–1850"
 
 #: src/components/Home.tsx:18
 msgid "The Database of<0/>German-Language<1/>One-Act Plays<2/>1740–1850"
-msgstr "lipu sona<0/>pi pali musi pi lipu wan<1/>kepeken toki Tonsi<2/>lon 1740–1850"
+msgstr "lipu sona<0/>pi pali musi pi lipu wan<1/>kepeken toki Tosi<2/>lon 1740–1850"
 
 #: src/components/Map.tsx:60
 msgid "This map shows all plot locations extractable from the setting information at the beginning of a play. Denominations and demarcations on the map are provided by OpenStreetMap and are therefore ahistorical in relation to the time of action and creation of a play."


### PR DESCRIPTION
_mi pakala!_ (I’m sorry!)

This PR fixes a typo in the Toki Pona translation. It now uses the standard term for German, [_toki Tosi_](https://wikipesija.org/wiki/toki_Tosi).